### PR TITLE
Merchant Statistics

### DIFF
--- a/app/controllers/merchants_controller.rb
+++ b/app/controllers/merchants_controller.rb
@@ -9,6 +9,9 @@ class MerchantsController < ApplicationController
     end
     @top_three_merchants_by_revenue = @merchants.top_merchants_by_revenue(3)
     @top_three_merchants_by_fulfillment = @merchants.top_merchants_by_fulfillment_time(3)
+    @top_ten_merchants_by_items_this_month = @merchants.top_merchants_by_month_items(10)
+    @top_ten_merchants_by_items_last_month = @merchants.top_merchants_by_month_items(10, Time.now.month - 1)
+
     @bottom_three_merchants_by_fulfillment = @merchants.bottom_merchants_by_fulfillment_time(3)
     @top_states_by_order_count = User.top_user_states_by_order_count(3)
     @top_cities_by_order_count = User.top_user_cities_by_order_count(3)

--- a/app/controllers/merchants_controller.rb
+++ b/app/controllers/merchants_controller.rb
@@ -7,11 +7,18 @@ class MerchantsController < ApplicationController
     else
       @merchants = User.active_merchants
     end
+    if current_user
+      @user = current_user
+      @top_five_merchants_by_fastest_fulfillment_state = @merchants.top_merchants_by_fulfilled_orders_fastest_state(@user, 5)
+      @top_five_merchants_by_fastest_fulfillment_city = @merchants.top_merchants_by_fulfilled_orders_fastest_city(@user, 5)
+    end
+
     @top_three_merchants_by_revenue = @merchants.top_merchants_by_revenue(3)
     @top_three_merchants_by_fulfillment = @merchants.top_merchants_by_fulfillment_time(3)
     @top_ten_merchants_by_items_this_month = @merchants.top_merchants_by_month_items(10)
-    @top_ten_merchants_by_items_last_month = @merchants.top_merchants_by_month_items(10, Time.now.month - 1)
-
+    @top_ten_merchants_by_items_last_month = @merchants.top_merchants_by_month_items(10, 1.month.ago.month)
+    @top_ten_merchants_by_noncancelled_orders_this_month = @merchants.top_merchants_by_fulfilled_orders(10)
+    @top_ten_merchants_by_noncancelled_orders_last_month = @merchants.top_merchants_by_fulfilled_orders(10, 1.month.ago.month)
     @bottom_three_merchants_by_fulfillment = @merchants.bottom_merchants_by_fulfillment_time(3)
     @top_states_by_order_count = User.top_user_states_by_order_count(3)
     @top_cities_by_order_count = User.top_user_cities_by_order_count(3)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -147,4 +147,24 @@ class User < ApplicationRecord
          .order('total DESC')
          .limit(limit)
   end
+
+
+
+  def self.top_merchants_by_month_items(limit)
+    merchants_sorted_by_month_items.limit(limit)
+  end
+
+  def self.merchants_sorted_by_month_items(month = Time.now.month)
+    self.joins(:items)
+        .joins('join order_items on items.id = order_items.item_id')
+        .joins('join orders on orders.id = order_items.order_id')
+        .select('users.*, sum(order_items.quantity) AS total_month_items')
+        .where('orders.status = 1')
+        .where('order_items.fulfilled = true')
+        .where('EXTRACT(MONTH FROM order_items.updated_at) = ?', month)
+        .group(:id)
+        .order('total_month_items DESC')
+  end
+
+
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -150,8 +150,8 @@ class User < ApplicationRecord
 
 
 
-  def self.top_merchants_by_month_items(limit)
-    merchants_sorted_by_month_items.limit(limit)
+  def self.top_merchants_by_month_items(limit, month = Time.now.month)
+    merchants_sorted_by_month_items(month).limit(limit)
   end
 
   def self.merchants_sorted_by_month_items(month = Time.now.month)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -161,6 +161,7 @@ class User < ApplicationRecord
         .select('users.*, sum(order_items.quantity) AS total_month_items')
         .where('orders.status = 1')
         .where('order_items.fulfilled = true')
+        .where('EXTRACT(YEAR FROM order_items.updated_at) = ?', Time.now.year)
         .where('EXTRACT(MONTH FROM order_items.updated_at) = ?', month)
         .group(:id)
         .order('total_month_items DESC')

--- a/app/views/merchants/index.html.erb
+++ b/app/views/merchants/index.html.erb
@@ -1,16 +1,8 @@
 <h1>Merchant List</h1>
 <%= tag.div class: "card" do %>
   <%= tag.section class: "statistics card-body float-left m-4" do %>
-    <%= tag.section id: "top-three-merchants-revenue", class: "card-body float-left m-2" do %>
-      <h5 class="card-title">Top Merchants by Revenue</h5>
-      <ul>
-        <% @top_three_merchants_by_revenue.each do |merchant| %>
-          <li><%= link_to merchant.name, merchant_path(merchant) %>: <%= number_to_currency(merchant.total) %></li>
-        <% end %>
-      </ul>
-    <% end %>
     <%= tag.section id: "top-three-merchants-fulfillment", class: "card-body float-left m-2" do %>
-      <h5 class="card-title">Best Fulfillment Times</h5>
+      <h5 class="card-title">Top Merchants by Fulfillment Time</h5>
       <ul>
         <% @top_three_merchants_by_fulfillment.each do |merchant| %>
           <li><%= link_to merchant.name, merchant_path(merchant) %>: <%= time_as_words(merchant.fulfillment_time) %></li>
@@ -18,7 +10,7 @@
       </ul>
     <% end %>
     <%= tag.section id: "bottom-three-merchants-fulfillment", class: "card-body float-left m-2" do %>
-      <h5 class="card-title">Worst Fulfillment Times</h5>
+      <h5 class="card-title">Worst Merchants by Fulfillment Time</h5>
       <ul>
         <% @bottom_three_merchants_by_fulfillment.each do |merchant| %>
           <li><%= link_to merchant.name, merchant_path(merchant) %>: <%= time_as_words(merchant.fulfillment_time) %></li>
@@ -53,6 +45,64 @@
         </ul>
       <% end %>
     <% end %>
+    <%= tag.section id: "top-ten-merchants-noncancelled-this-month", class: "card-body float-left m-2" do %>
+      <h5 class="card-title">Top Merchants Who Fulfilled<br>Orders This Month</h5>
+      <% if !@top_ten_merchants_by_noncancelled_orders_this_month.empty? %>
+        <ul>
+          <% @top_ten_merchants_by_noncancelled_orders_this_month.each do |merchant| %>
+            <li><%= link_to merchant.name, merchant_path(merchant) %>: <%= number_to_currency(merchant.total_revenue) %> Fulfilled Value</li>
+          <% end %>
+        </ul>
+      <% else %>
+        <ul>
+          <li>N/A</li>
+        </ul>
+      <% end %>
+    <% end %>
+    <%= tag.section id: "top-ten-merchants-noncancelled-last-month", class: "card-body float-left m-2" do %>
+      <h5 class="card-title">Top Merchants Who Fulfilled <br>Orders Last Month</h5>
+      <% if !@top_ten_merchants_by_noncancelled_orders_last_month.empty? %>
+        <ul>
+          <% @top_ten_merchants_by_noncancelled_orders_last_month.each do |merchant| %>
+            <li><%= link_to merchant.name, merchant_path(merchant) %>: <%= number_to_currency(merchant.total_revenue) %> Fulfilled Value</li>
+          <% end %>
+        </ul>
+      <% else %>
+        <ul>
+          <li>N/A</li>
+        </ul>
+      <% end %>
+    <% end %>
+    <% if @user %>
+      <%= tag.section id: "top-five-merchants-fulfilled-fastest-state", class: "card-body float-left m-2" do %>
+        <h5 class="card-title">Top Merchants Who Fulfilled <br>Orders Fastest To My State<br>(<%= @user.state %>)</h5>
+        <% if !@top_five_merchants_by_fastest_fulfillment_state.empty? %>
+          <ul>
+            <% @top_five_merchants_by_fastest_fulfillment_state.each do |merchant| %>
+              <li><%= link_to merchant.name, merchant_path(merchant) %>: <%= time_as_words(merchant.avg_fulfillment_time) %></li>
+            <% end %>
+          </ul>
+        <% else %>
+          <ul>
+            <li>N/A</li>
+          </ul>
+        <% end %>
+      <% end %>
+      <%= tag.section id: "top-five-merchants-fulfilled-fastest-city", class: "card-body float-left m-2" do %>
+        <h5 class="card-title">Top Merchants Who Fulfilled <br>Orders Fastest To My City<br>(<%= @user.city %>, <%= @user.state %>)</h5>
+        <% if !@top_five_merchants_by_fastest_fulfillment_city.empty? %>
+          <ul>
+            <% @top_five_merchants_by_fastest_fulfillment_city.each do |merchant| %>
+              <li><%= link_to merchant.name, merchant_path(merchant) %>: <%= time_as_words(merchant.avg_fulfillment_time) %></li>
+            <% end %>
+          </ul>
+        <% else %>
+          <ul>
+            <li>N/A</li>
+          </ul>
+        <% end %>
+      <% end %>
+    <% end %>
     <%= tag.section id: "top-states-by-order", class: "card-body float-left m-2" do %>
       <h5 class="card-title">Top States by Order</h5>
       <ul>
@@ -66,6 +116,14 @@
       <ul>
         <% @top_cities_by_order_count.each do |result| %>
           <li><%= result.city %>, <%= result.state %>: <%= pluralize(result.order_count, "order") %></li>
+        <% end %>
+      </ul>
+    <% end %>
+    <%= tag.section id: "top-three-merchants-revenue", class: "card-body float-left m-2" do %>
+      <h5 class="card-title">Top Merchants by Revenue</h5>
+      <ul>
+        <% @top_three_merchants_by_revenue.each do |merchant| %>
+          <li><%= link_to merchant.name, merchant_path(merchant) %>: <%= number_to_currency(merchant.total) %></li>
         <% end %>
       </ul>
     <% end %>

--- a/app/views/merchants/index.html.erb
+++ b/app/views/merchants/index.html.erb
@@ -25,6 +25,34 @@
         <% end %>
       </ul>
     <% end %>
+    <%= tag.section id: "top-ten-merchants-this-month", class: "card-body float-left m-2" do %>
+      <h5 class="card-title">Top Merchants by Items This Month</h5>
+      <% if !@top_ten_merchants_by_items_this_month.empty? %>
+        <ul>
+          <% @top_ten_merchants_by_items_this_month.each do |merchant| %>
+            <li><%= link_to merchant.name, merchant_path(merchant) %>: <%= pluralize(merchant.total_month_items, 'Item') %></li>
+          <% end %>
+        </ul>
+      <% else %>
+        <ul>
+          <li>N/A</li>
+        </ul>
+      <% end %>
+    <% end %>
+    <%= tag.section id: "top-ten-merchants-last-month", class: "card-body float-left m-2" do %>
+      <h5 class="card-title">Top Merchants by Items Last Month</h5>
+      <% if !@top_ten_merchants_by_items_last_month.empty? %>
+        <ul>
+          <% @top_ten_merchants_by_items_last_month.each do |merchant| %>
+            <li><%= link_to merchant.name, merchant_path(merchant) %>: <%= pluralize(merchant.total_month_items, 'Item') %></li>
+          <% end %>
+        </ul>
+      <% else %>
+        <ul>
+          <li>N/A</li>
+        </ul>
+      <% end %>
+    <% end %>
     <%= tag.section id: "top-states-by-order", class: "card-body float-left m-2" do %>
       <h5 class="card-title">Top States by Order</h5>
       <ul>

--- a/app/views/merchants/index.html.erb
+++ b/app/views/merchants/index.html.erb
@@ -25,7 +25,7 @@
         <% end %>
       </ul>
     <% end %>
-    <%= tag.section id: "top-ten-merchants-this-month", class: "card-body float-left m-2" do %>
+    <%= tag.section id: "top-ten-merchants-items-this-month", class: "card-body float-left m-2" do %>
       <h5 class="card-title">Top Merchants by Items This Month</h5>
       <% if !@top_ten_merchants_by_items_this_month.empty? %>
         <ul>
@@ -39,7 +39,7 @@
         </ul>
       <% end %>
     <% end %>
-    <%= tag.section id: "top-ten-merchants-last-month", class: "card-body float-left m-2" do %>
+    <%= tag.section id: "top-ten-merchants-items-last-month", class: "card-body float-left m-2" do %>
       <h5 class="card-title">Top Merchants by Items Last Month</h5>
       <% if !@top_ten_merchants_by_items_last_month.empty? %>
         <ul>

--- a/public/assets/application-084cef7b2b05864a8c827df267b88dfac018f3f6d98c4b065736c83ec1c290c4.css
+++ b/public/assets/application-084cef7b2b05864a8c827df267b88dfac018f3f6d98c4b065736c83ec1c290c4.css
@@ -7822,6 +7822,8 @@ button.bg-dark:focus {
 /* line 12, /Users/id/.rbenv/versions/2.4.5/lib/ruby/gems/2.4.0/gems/bootstrap-4.0.0/assets/stylesheets/bootstrap/utilities/_spacing.scss */
 .m-2 {
   margin: 0.5rem !important;
+  height: 40vw;
+  width: 40vw;
 }
 
 /* line 13, /Users/id/.rbenv/versions/2.4.5/lib/ruby/gems/2.4.0/gems/bootstrap-4.0.0/assets/stylesheets/bootstrap/utilities/_spacing.scss */

--- a/spec/features/merchant/index_spec.rb
+++ b/spec/features/merchant/index_spec.rb
@@ -216,7 +216,6 @@ RSpec.describe "merchant index workflow", type: :feature do
         o13 = create(:completed_order, user: u3)
         o14 = create(:completed_order, user: @u4)
 
-
         #Order_items updated_at (fulfilled) current time (this month)
         oi1 = create(:fulfilled_order_item, item: i4, order: o1, quantity: 1, created_at: 200.days.ago)
         oi2 = create(:fulfilled_order_item, item: i2, order: o1, quantity: 1, created_at: 200.days.ago)
@@ -254,6 +253,7 @@ RSpec.describe "merchant index workflow", type: :feature do
         oi26 = create(:fulfilled_order_item, item: i8, order: o6, quantity: 1, created_at: 200.days.ago, updated_at: 1.month.ago)
         oi27 = create(:fulfilled_order_item, item: i10, order: o6, quantity: 1, created_at: 200.days.ago, updated_at: 1.month.ago)
 
+        #Order_items ordered by users from different states
         oi28 = create(:fulfilled_order_item, item: i11, order: o11, quantity: 1, created_at: 221.days.ago, updated_at: 1.month.ago)
         oi29 = create(:fulfilled_order_item, item: i12, order: o12, quantity: 1, created_at: 220.days.ago, updated_at: 1.month.ago)
         oi30 = create(:fulfilled_order_item, item: i13, order: o13, quantity: 1, created_at: 211.days.ago, updated_at: 1.month.ago)
@@ -261,6 +261,7 @@ RSpec.describe "merchant index workflow", type: :feature do
         oi32 = create(:fulfilled_order_item, item: i15, order: o14, quantity: 1, created_at: 203.days.ago, updated_at: 1.month.ago)
         oi33 = create(:fulfilled_order_item, item: i16, order: o14, quantity: 1, created_at: 202.days.ago, updated_at: 1.month.ago)
 
+        #Order_items ordered by users from different cities in IA
         oi34 = create(:fulfilled_order_item, item: i1, order: o11, quantity: 1, price: 1, created_at: 201.days.ago, updated_at: 3.months.ago)
         oi35 = create(:fulfilled_order_item, item: i2, order: o11, quantity: 1, price: 1, created_at: 200.days.ago, updated_at: 3.months.ago)
         oi35 = create(:fulfilled_order_item, item: i3, order: o14, quantity: 1, price: 1, created_at: 300.days.ago, updated_at: 3.months.ago)

--- a/spec/features/merchant/index_spec.rb
+++ b/spec/features/merchant/index_spec.rb
@@ -221,18 +221,18 @@ RSpec.describe "merchant index workflow", type: :feature do
         oi9 = create(:fulfilled_order_item, item: i3, order: o6, quantity: 1, created_at: 200.days.ago)
         oi10 = create(:fulfilled_order_item, item: i5, order: o6, quantity: 1, created_at: 200.days.ago)
 
-        #Sad path testing
         #Item not fulfilled this month
-        oi11 = create(:fulfilled_order_item, item: i1, order: o7, created_at: 200.days.ago, updated_at: 60.days.ago, quantity: 5)
+        oi11 = create(:fulfilled_order_item, item: i1, order: o7, created_at: 200.days.ago, updated_at: 2.months.ago, quantity: 5)
+        oi34 = create(:fulfilled_order_item, item: i1, order: o7, created_at: 400.days.ago, updated_at: 1.year.ago, quantity: 5)
         #Item unfulfilled
-        oi12 = create(:order_item, item: i1, order: o8, created_at: 200.days.ago, updated_at: 3.days.ago, quantity: 5)
-        oi13 = create(:order_item, item: i1, order: o8, created_at: 200.days.ago, updated_at: 30.days.ago, quantity: 5)
+        oi12 = create(:order_item, item: i1, order: o8, created_at: 200.days.ago, quantity: 5)
+        oi13 = create(:order_item, item: i1, order: o8, created_at: 200.days.ago, updated_at: 1.month.ago, quantity: 5)
         #Order pending
-        oi14 = create(:fulfilled_order_item, item: i1, order: o9, created_at: 200.days.ago, updated_at: 3.days.ago, quantity: 5)
-        oi15 = create(:fulfilled_order_item, item: i1, order: o9, created_at: 200.days.ago, updated_at: 30.days.ago, quantity: 5)
+        oi14 = create(:fulfilled_order_item, item: i1, order: o9, created_at: 200.days.ago, quantity: 5)
+        oi15 = create(:fulfilled_order_item, item: i1, order: o9, created_at: 200.days.ago, updated_at: 1.month.ago, quantity: 5)
         #Order cancelled
-        oi16 = create(:fulfilled_order_item, item: i1, order: o10, created_at: 200.days.ago, updated_at: 3.days.ago, quantity: 5)
-        oi17 = create(:fulfilled_order_item, item: i1, order: o10, created_at: 200.days.ago, updated_at: 30.days.ago, quantity: 5)
+        oi16 = create(:fulfilled_order_item, item: i1, order: o10, created_at: 200.days.ago, quantity: 5)
+        oi17 = create(:fulfilled_order_item, item: i1, order: o10, created_at: 200.days.ago, updated_at: 1.month.ago, quantity: 5)
 
         #Order_items updated_at (fulfilled) 1 month ago (last month)
         oi18 = create(:fulfilled_order_item, item: i9, order: o1, quantity: 1, created_at: 200.days.ago, updated_at: 1.month.ago)

--- a/spec/features/merchant/index_spec.rb
+++ b/spec/features/merchant/index_spec.rb
@@ -187,7 +187,10 @@ RSpec.describe "merchant index workflow", type: :feature do
 
     describe "shows advanced merchant statistics" do
       before :each do
-        u1 = create(:user)
+        u1 = create(:user, state: "CO", city: "Fairfield")
+        u2 = create(:user, state: "IA", city: "Fairfield")
+        u3 = create(:user, state: "OK", city: "OKC")
+        u4 = create(:user, state: "IA", city: "Des Moines")
         @m1, @m2, @m3, @m4, @m5, @m6, @m7, @m8, @m9, @m10, @m11, @m12, @m13, @m14, @m15, @m16 = create_list(:merchant, 16)
         i1 = create(:item, merchant_id: @m1.id)
         i2 = create(:item, merchant_id: @m2.id)
@@ -208,6 +211,10 @@ RSpec.describe "merchant index workflow", type: :feature do
         o1, o2, o3, o4, o5, o6 , o7, o8 = create_list(:completed_order, 8, user: u1)
         o9 = create(:order, user: u1)
         o10 = create(:cancelled_order, user: u1)
+        o11 = create(:completed_order, user: u2)
+        o12 = create(:completed_order, user: u3)
+        o13 = create(:order, user: u4)
+
 
         #Order_items updated_at (fulfilled) current time (this month)
         oi1 = create(:fulfilled_order_item, item: i4, order: o1, quantity: 1, created_at: 200.days.ago)
@@ -228,8 +235,8 @@ RSpec.describe "merchant index workflow", type: :feature do
         oi12 = create(:order_item, item: i1, order: o8, created_at: 200.days.ago, quantity: 5)
         oi13 = create(:order_item, item: i1, order: o8, created_at: 200.days.ago, updated_at: 1.month.ago, quantity: 5)
         #Order pending
-        oi14 = create(:fulfilled_order_item, item: i1, order: o9, created_at: 200.days.ago, quantity: 5)
-        oi15 = create(:fulfilled_order_item, item: i1, order: o9, created_at: 200.days.ago, updated_at: 1.month.ago, quantity: 5)
+        oi14 = create(:fulfilled_order_item, item: i11, order: o9, created_at: 200.days.ago, quantity: 5)
+        oi15 = create(:fulfilled_order_item, item: i11, order: o9, created_at: 200.days.ago, updated_at: 1.month.ago, quantity: 5)
         #Order cancelled
         oi16 = create(:fulfilled_order_item, item: i1, order: o10, created_at: 200.days.ago, quantity: 5)
         oi17 = create(:fulfilled_order_item, item: i1, order: o10, created_at: 200.days.ago, updated_at: 1.month.ago, quantity: 5)
@@ -246,20 +253,18 @@ RSpec.describe "merchant index workflow", type: :feature do
         oi26 = create(:fulfilled_order_item, item: i8, order: o6, quantity: 1, created_at: 200.days.ago, updated_at: 1.month.ago)
         oi27 = create(:fulfilled_order_item, item: i10, order: o6, quantity: 1, created_at: 200.days.ago, updated_at: 1.month.ago)
 
-        oi28 = create(:fulfilled_order_item, item: i11, order: o6, quantity: 1, created_at: 200.days.ago, updated_at: 1.month.ago)
-        oi29 = create(:fulfilled_order_item, item: i12, order: o6, quantity: 1, created_at: 200.days.ago, updated_at: 1.month.ago)
-        oi30 = create(:fulfilled_order_item, item: i13, order: o6, quantity: 1, created_at: 200.days.ago, updated_at: 1.month.ago)
-        oi31 = create(:fulfilled_order_item, item: i14, order: o6, quantity: 1, created_at: 200.days.ago, updated_at: 1.month.ago)
-        oi32 = create(:fulfilled_order_item, item: i15, order: o6, quantity: 1, created_at: 200.days.ago, updated_at: 1.month.ago)
-        oi33 = create(:fulfilled_order_item, item: i16, order: o6, quantity: 1, created_at: 200.days.ago, updated_at: 1.month.ago)
-
-
+        oi28 = create(:fulfilled_order_item, item: i11, order: o11, quantity: 1, created_at: 220.days.ago, updated_at: 1.month.ago)
+        oi29 = create(:fulfilled_order_item, item: i12, order: o11, quantity: 1, created_at: 220.days.ago, updated_at: 1.month.ago)
+        oi30 = create(:fulfilled_order_item, item: i13, order: o12, quantity: 1, created_at: 210.days.ago, updated_at: 1.month.ago)
+        oi31 = create(:fulfilled_order_item, item: i14, order: o12, quantity: 1, created_at: 210.days.ago, updated_at: 1.month.ago)
+        oi32 = create(:fulfilled_order_item, item: i15, order: o13, quantity: 1, created_at: 200.days.ago, updated_at: 1.month.ago)
+        oi33 = create(:fulfilled_order_item, item: i16, order: o13, quantity: 1, created_at: 200.days.ago, updated_at: 1.month.ago)
       end
 
       it "top 10 merchants by month items, this month" do
         visit merchants_path
 
-        within("#top-ten-merchants-this-month") do
+        within("#top-ten-merchants-items-this-month") do
           expect(page).to have_content("#{@m3.name}: 4 Items")
           expect(page).to have_content("#{@m2.name}: 2 Items")
           expect(page).to have_content("#{@m4.name}: 2 Items")
@@ -271,7 +276,7 @@ RSpec.describe "merchant index workflow", type: :feature do
       it "top 10 merchants by month items, last month" do
         visit merchants_path
 
-        within("#top-ten-merchants-last-month") do
+        within("#top-ten-merchants-items-last-month") do
           expect(page).to have_content("#{@m8.name}: 4 Items")
           expect(page).to have_content("#{@m9.name}: 2 Items")
           expect(page).to have_content("#{@m7.name}: 2 Items")
@@ -282,6 +287,36 @@ RSpec.describe "merchant index workflow", type: :feature do
           expect(page).to have_content("#{@m14.name}: 1 Item")
           expect(page).to have_content("#{@m15.name}: 1 Item")
           expect(page).to have_content("#{@m16.name}: 1 Item")
+        end
+      end
+
+      it "top 10 merchants by month non-cancelled orders, this month" do
+        visit merchants_path
+
+        within("#top-ten-merchants-noncancelled-this-month") do
+          expect(page).to have_content("#{@m11.name}: 5 Items")
+          expect(page).to have_content("#{@m3.name}: 4 Items")
+          expect(page).to have_content("#{@m2.name}: 2 Items")
+          expect(page).to have_content("#{@m4.name}: 2 Items")
+          expect(page).to have_content("#{@m1.name}: 1 Item")
+          expect(page).to have_content("#{@m5.name}: 1 Item")
+        end
+      end
+
+      it "top 10 merchants by month non-cancelled orders, last month" do
+        visit merchants_path
+
+        within("#top-ten-merchants-noncancelled-last-month") do
+          expect(page).to have_content("#{@m11.name}: 5 Items")
+          expect(page).to have_content("#{@m8.name}: 4 Items")
+          expect(page).to have_content("#{@m9.name}: 2 Items")
+          expect(page).to have_content("#{@m7.name}: 2 Items")
+          expect(page).to have_content("#{@m6.name}: 1 Item")
+          expect(page).to have_content("#{@m10.name}: 1 Item")
+          expect(page).to have_content("#{@m12.name}: 1 Item")
+          expect(page).to have_content("#{@m13.name}: 1 Item")
+          expect(page).to have_content("#{@m14.name}: 1 Item")
+          expect(page).to have_content("#{@m15.name}: 1 Item")
         end
       end
 

--- a/spec/features/merchant/index_spec.rb
+++ b/spec/features/merchant/index_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe "merchant index workflow", type: :feature do
         u4 = create(:user, state: "IA", city: "Des Moines")
         u5 = create(:user, state: "IA", city: "Des Moines")
         u6 = create(:user, state: "IA", city: "Des Moines")
-        @m1, @m2, @m3, @m4, @m5, @m6, @m7 = create_list(:merchant, 7)
+        @m1, @m2, @m3, @m4, @m5, @m6, @m7 = create_list(:merchant,7)
         i1 = create(:item, merchant_id: @m1.id)
         i2 = create(:item, merchant_id: @m2.id)
         i3 = create(:item, merchant_id: @m3.id)
@@ -183,6 +183,108 @@ RSpec.describe "merchant index workflow", type: :feature do
           expect(page).to have_content("Order #{@o3.id}: 8 items")
         end
       end
+    end
+
+    describe "shows advanced merchant statistics" do
+      before :each do
+        u1 = create(:user)
+        @m1, @m2, @m3, @m4, @m5, @m6, @m7, @m8, @m9, @m10, @m11, @m12, @m13, @m14, @m15, @m16 = create_list(:merchant, 16)
+        i1 = create(:item, merchant_id: @m1.id)
+        i2 = create(:item, merchant_id: @m2.id)
+        i3 = create(:item, merchant_id: @m3.id)
+        i4 = create(:item, merchant_id: @m4.id)
+        i5 = create(:item, merchant_id: @m5.id)
+        i6 = create(:item, merchant_id: @m6.id)
+        i7 = create(:item, merchant_id: @m7.id)
+        i8 = create(:item, merchant_id: @m8.id)
+        i9 = create(:item, merchant_id: @m9.id)
+        i10 = create(:item, merchant_id: @m10.id)
+        i11 = create(:item, merchant_id: @m11.id)
+        i12 = create(:item, merchant_id: @m12.id)
+        i13 = create(:item, merchant_id: @m13.id)
+        i14 = create(:item, merchant_id: @m14.id)
+        i15 = create(:item, merchant_id: @m15.id)
+        i16 = create(:item, merchant_id: @m16.id)
+        o1, o2, o3, o4, o5, o6 , o7, o8 = create_list(:completed_order, 8, user: u1)
+        o9 = create(:order, user: u1)
+        o10 = create(:cancelled_order, user: u1)
+
+        #Order_items updated_at (fulfilled) current time (this month)
+        oi1 = create(:fulfilled_order_item, item: i4, order: o1, quantity: 1, created_at: 200.days.ago)
+        oi2 = create(:fulfilled_order_item, item: i2, order: o1, quantity: 1, created_at: 200.days.ago)
+        oi3 = create(:fulfilled_order_item, item: i3, order: o1, quantity: 1, created_at: 200.days.ago)
+        oi4 = create(:fulfilled_order_item, item: i3, order: o2, quantity: 1, created_at: 200.days.ago)
+        oi5 = create(:fulfilled_order_item, item: i2, order: o2, quantity: 1, created_at: 200.days.ago)
+        oi6 = create(:fulfilled_order_item, item: i4, order: o3, quantity: 1, created_at: 200.days.ago)
+        oi7 = create(:fulfilled_order_item, item: i3, order: o4, quantity: 1, created_at: 200.days.ago)
+        oi8 = create(:fulfilled_order_item, item: i1, order: o5, quantity: 1, created_at: 200.days.ago)
+        oi9 = create(:fulfilled_order_item, item: i3, order: o6, quantity: 1, created_at: 200.days.ago)
+        oi10 = create(:fulfilled_order_item, item: i5, order: o6, quantity: 1, created_at: 200.days.ago)
+
+        #Sad path testing
+        #Item not fulfilled this month
+        oi11 = create(:fulfilled_order_item, item: i1, order: o7, created_at: 200.days.ago, updated_at: 60.days.ago, quantity: 5)
+        #Item unfulfilled
+        oi12 = create(:order_item, item: i1, order: o8, created_at: 200.days.ago, updated_at: 3.days.ago, quantity: 5)
+        oi13 = create(:order_item, item: i1, order: o8, created_at: 200.days.ago, updated_at: 30.days.ago, quantity: 5)
+        #Order pending
+        oi14 = create(:fulfilled_order_item, item: i1, order: o9, created_at: 200.days.ago, updated_at: 3.days.ago, quantity: 5)
+        oi15 = create(:fulfilled_order_item, item: i1, order: o9, created_at: 200.days.ago, updated_at: 30.days.ago, quantity: 5)
+        #Order cancelled
+        oi16 = create(:fulfilled_order_item, item: i1, order: o10, created_at: 200.days.ago, updated_at: 3.days.ago, quantity: 5)
+        oi17 = create(:fulfilled_order_item, item: i1, order: o10, created_at: 200.days.ago, updated_at: 30.days.ago, quantity: 5)
+
+        #Order_items updated_at (fulfilled) 1 month ago (last month)
+        oi18 = create(:fulfilled_order_item, item: i9, order: o1, quantity: 1, created_at: 200.days.ago, updated_at: 1.month.ago)
+        oi19 = create(:fulfilled_order_item, item: i7, order: o1, quantity: 1, created_at: 200.days.ago, updated_at: 1.month.ago)
+        oi20 = create(:fulfilled_order_item, item: i8, order: o1, quantity: 1, created_at: 200.days.ago, updated_at: 1.month.ago)
+        oi21 = create(:fulfilled_order_item, item: i8, order: o2, quantity: 1, created_at: 200.days.ago, updated_at: 1.month.ago)
+        oi22 = create(:fulfilled_order_item, item: i7, order: o2, quantity: 1, created_at: 200.days.ago, updated_at: 1.month.ago)
+        oi23 = create(:fulfilled_order_item, item: i9, order: o3, quantity: 1, created_at: 200.days.ago, updated_at: 1.month.ago)
+        oi24 = create(:fulfilled_order_item, item: i8, order: o4, quantity: 1, created_at: 200.days.ago, updated_at: 1.month.ago)
+        oi25 = create(:fulfilled_order_item, item: i6, order: o5, quantity: 1, created_at: 200.days.ago, updated_at: 1.month.ago)
+        oi26 = create(:fulfilled_order_item, item: i8, order: o6, quantity: 1, created_at: 200.days.ago, updated_at: 1.month.ago)
+        oi27 = create(:fulfilled_order_item, item: i10, order: o6, quantity: 1, created_at: 200.days.ago, updated_at: 1.month.ago)
+
+        oi28 = create(:fulfilled_order_item, item: i11, order: o6, quantity: 1, created_at: 200.days.ago, updated_at: 1.month.ago)
+        oi29 = create(:fulfilled_order_item, item: i12, order: o6, quantity: 1, created_at: 200.days.ago, updated_at: 1.month.ago)
+        oi30 = create(:fulfilled_order_item, item: i13, order: o6, quantity: 1, created_at: 200.days.ago, updated_at: 1.month.ago)
+        oi31 = create(:fulfilled_order_item, item: i14, order: o6, quantity: 1, created_at: 200.days.ago, updated_at: 1.month.ago)
+        oi32 = create(:fulfilled_order_item, item: i15, order: o6, quantity: 1, created_at: 200.days.ago, updated_at: 1.month.ago)
+        oi33 = create(:fulfilled_order_item, item: i16, order: o6, quantity: 1, created_at: 200.days.ago, updated_at: 1.month.ago)
+
+
+      end
+
+      it "top 10 merchants by month items, this month" do
+        visit merchants_path
+
+        within("#top-ten-merchants-this-month") do
+          expect(page).to have_content("#{@m3.name}: 4 Items")
+          expect(page).to have_content("#{@m2.name}: 2 Items")
+          expect(page).to have_content("#{@m4.name}: 2 Items")
+          expect(page).to have_content("#{@m1.name}: 1 Item")
+          expect(page).to have_content("#{@m5.name}: 1 Item")
+        end
+      end
+
+      it "top 10 merchants by month items, last month" do
+        visit merchants_path
+
+        within("#top-ten-merchants-last-month") do
+          expect(page).to have_content("#{@m8.name}: 4 Items")
+          expect(page).to have_content("#{@m9.name}: 2 Items")
+          expect(page).to have_content("#{@m7.name}: 2 Items")
+          expect(page).to have_content("#{@m6.name}: 1 Item")
+          expect(page).to have_content("#{@m10.name}: 1 Item")
+          expect(page).to have_content("#{@m12.name}: 1 Item")
+          expect(page).to have_content("#{@m13.name}: 1 Item")
+          expect(page).to have_content("#{@m14.name}: 1 Item")
+          expect(page).to have_content("#{@m15.name}: 1 Item")
+          expect(page).to have_content("#{@m16.name}: 1 Item")
+        end
+      end
+
     end
   end
 end

--- a/spec/features/merchant/index_spec.rb
+++ b/spec/features/merchant/index_spec.rb
@@ -211,9 +211,10 @@ RSpec.describe "merchant index workflow", type: :feature do
         o1, o2, o3, o4, o5, o6 , o7, o8 = create_list(:completed_order, 8, user: u1)
         o9 = create(:order, user: u1)
         o10 = create(:cancelled_order, user: u1)
-        o11 = create(:completed_order, user: u2)
-        o12 = create(:completed_order, user: u3)
-        o13 = create(:order, user: u4)
+        o11 = create(:order, user: u2)
+        o12 = create(:completed_order, user: u2)
+        o13 = create(:completed_order, user: u3)
+        o14 = create(:completed_order, user: u4)
 
 
         #Order_items updated_at (fulfilled) current time (this month)
@@ -254,11 +255,11 @@ RSpec.describe "merchant index workflow", type: :feature do
         oi27 = create(:fulfilled_order_item, item: i10, order: o6, quantity: 1, created_at: 200.days.ago, updated_at: 1.month.ago)
 
         oi28 = create(:fulfilled_order_item, item: i11, order: o11, quantity: 1, created_at: 220.days.ago, updated_at: 1.month.ago)
-        oi29 = create(:fulfilled_order_item, item: i12, order: o11, quantity: 1, created_at: 220.days.ago, updated_at: 1.month.ago)
-        oi30 = create(:fulfilled_order_item, item: i13, order: o12, quantity: 1, created_at: 210.days.ago, updated_at: 1.month.ago)
-        oi31 = create(:fulfilled_order_item, item: i14, order: o12, quantity: 1, created_at: 210.days.ago, updated_at: 1.month.ago)
-        oi32 = create(:fulfilled_order_item, item: i15, order: o13, quantity: 1, created_at: 200.days.ago, updated_at: 1.month.ago)
-        oi33 = create(:fulfilled_order_item, item: i16, order: o13, quantity: 1, created_at: 200.days.ago, updated_at: 1.month.ago)
+        oi29 = create(:fulfilled_order_item, item: i12, order: o12, quantity: 1, created_at: 220.days.ago, updated_at: 1.month.ago)
+        oi30 = create(:fulfilled_order_item, item: i13, order: o13, quantity: 1, created_at: 210.days.ago, updated_at: 1.month.ago)
+        oi31 = create(:fulfilled_order_item, item: i14, order: o13, quantity: 1, created_at: 210.days.ago, updated_at: 1.month.ago)
+        oi32 = create(:fulfilled_order_item, item: i15, order: o14, quantity: 1, created_at: 200.days.ago, updated_at: 1.month.ago)
+        oi33 = create(:fulfilled_order_item, item: i16, order: o14, quantity: 1, created_at: 200.days.ago, updated_at: 1.month.ago)
       end
 
       it "top 10 merchants by month items, this month" do

--- a/spec/features/merchant/index_spec.rb
+++ b/spec/features/merchant/index_spec.rb
@@ -188,9 +188,9 @@ RSpec.describe "merchant index workflow", type: :feature do
     describe "shows advanced merchant statistics" do
       before :each do
         u1 = create(:user, state: "CO", city: "Fairfield")
-        u2 = create(:user, state: "IA", city: "Fairfield")
+        @u2 = create(:user, state: "IA", city: "Fairfield")
         u3 = create(:user, state: "OK", city: "OKC")
-        u4 = create(:user, state: "IA", city: "Des Moines")
+        @u4 = create(:user, state: "IA", city: "Des Moines")
         @m1, @m2, @m3, @m4, @m5, @m6, @m7, @m8, @m9, @m10, @m11, @m12, @m13, @m14, @m15, @m16 = create_list(:merchant, 16)
         i1 = create(:item, merchant_id: @m1.id)
         i2 = create(:item, merchant_id: @m2.id)
@@ -211,10 +211,10 @@ RSpec.describe "merchant index workflow", type: :feature do
         o1, o2, o3, o4, o5, o6 , o7, o8 = create_list(:completed_order, 8, user: u1)
         o9 = create(:order, user: u1)
         o10 = create(:cancelled_order, user: u1)
-        o11 = create(:order, user: u2)
-        o12 = create(:completed_order, user: u2)
+        o11 = create(:order, user: @u2)
+        o12 = create(:completed_order, user: @u2)
         o13 = create(:completed_order, user: u3)
-        o14 = create(:completed_order, user: u4)
+        o14 = create(:completed_order, user: @u4)
 
 
         #Order_items updated_at (fulfilled) current time (this month)
@@ -231,7 +231,7 @@ RSpec.describe "merchant index workflow", type: :feature do
 
         #Item not fulfilled this month
         oi11 = create(:fulfilled_order_item, item: i1, order: o7, created_at: 200.days.ago, updated_at: 2.months.ago, quantity: 5)
-        oi34 = create(:fulfilled_order_item, item: i1, order: o7, created_at: 400.days.ago, updated_at: 1.year.ago, quantity: 5)
+        oi50 = create(:fulfilled_order_item, item: i1, order: o7, created_at: 400.days.ago, updated_at: 1.year.ago, quantity: 5)
         #Item unfulfilled
         oi12 = create(:order_item, item: i1, order: o8, created_at: 200.days.ago, quantity: 5)
         oi13 = create(:order_item, item: i1, order: o8, created_at: 200.days.ago, updated_at: 1.month.ago, quantity: 5)
@@ -254,12 +254,19 @@ RSpec.describe "merchant index workflow", type: :feature do
         oi26 = create(:fulfilled_order_item, item: i8, order: o6, quantity: 1, created_at: 200.days.ago, updated_at: 1.month.ago)
         oi27 = create(:fulfilled_order_item, item: i10, order: o6, quantity: 1, created_at: 200.days.ago, updated_at: 1.month.ago)
 
-        oi28 = create(:fulfilled_order_item, item: i11, order: o11, quantity: 1, created_at: 220.days.ago, updated_at: 1.month.ago)
+        oi28 = create(:fulfilled_order_item, item: i11, order: o11, quantity: 1, created_at: 221.days.ago, updated_at: 1.month.ago)
         oi29 = create(:fulfilled_order_item, item: i12, order: o12, quantity: 1, created_at: 220.days.ago, updated_at: 1.month.ago)
-        oi30 = create(:fulfilled_order_item, item: i13, order: o13, quantity: 1, created_at: 210.days.ago, updated_at: 1.month.ago)
+        oi30 = create(:fulfilled_order_item, item: i13, order: o13, quantity: 1, created_at: 211.days.ago, updated_at: 1.month.ago)
         oi31 = create(:fulfilled_order_item, item: i14, order: o13, quantity: 1, created_at: 210.days.ago, updated_at: 1.month.ago)
-        oi32 = create(:fulfilled_order_item, item: i15, order: o14, quantity: 1, created_at: 200.days.ago, updated_at: 1.month.ago)
-        oi33 = create(:fulfilled_order_item, item: i16, order: o14, quantity: 1, created_at: 200.days.ago, updated_at: 1.month.ago)
+        oi32 = create(:fulfilled_order_item, item: i15, order: o14, quantity: 1, created_at: 203.days.ago, updated_at: 1.month.ago)
+        oi33 = create(:fulfilled_order_item, item: i16, order: o14, quantity: 1, created_at: 202.days.ago, updated_at: 1.month.ago)
+
+        oi34 = create(:fulfilled_order_item, item: i1, order: o11, quantity: 1, price: 1, created_at: 201.days.ago, updated_at: 3.months.ago)
+        oi35 = create(:fulfilled_order_item, item: i2, order: o11, quantity: 1, price: 1, created_at: 200.days.ago, updated_at: 3.months.ago)
+        oi35 = create(:fulfilled_order_item, item: i3, order: o14, quantity: 1, price: 1, created_at: 300.days.ago, updated_at: 3.months.ago)
+        oi35 = create(:fulfilled_order_item, item: i4, order: o14, quantity: 1, price: 1, created_at: 301.days.ago, updated_at: 3.months.ago)
+        oi35 = create(:fulfilled_order_item, item: i5, order: o14, quantity: 1, price: 1, created_at: 302.days.ago, updated_at: 3.months.ago)
+        oi35 = create(:fulfilled_order_item, item: i6, order: o14, quantity: 1, price: 1, created_at: 303.days.ago, updated_at: 3.months.ago)
       end
 
       it "top 10 merchants by month items, this month" do
@@ -295,12 +302,12 @@ RSpec.describe "merchant index workflow", type: :feature do
         visit merchants_path
 
         within("#top-ten-merchants-noncancelled-this-month") do
-          expect(page).to have_content("#{@m11.name}: 5 Items")
-          expect(page).to have_content("#{@m3.name}: 4 Items")
-          expect(page).to have_content("#{@m2.name}: 2 Items")
-          expect(page).to have_content("#{@m4.name}: 2 Items")
-          expect(page).to have_content("#{@m1.name}: 1 Item")
-          expect(page).to have_content("#{@m5.name}: 1 Item")
+          expect(page).to have_content("#{@m11.name}: $120.00 Fulfilled Value")
+          expect(page).to have_content("#{@m3.name}: $40.50 Fulfilled Value")
+          expect(page).to have_content("#{@m5.name}: $16.50 Fulfilled Value")
+          expect(page).to have_content("#{@m1.name}: $13.50 Fulfilled Value")
+          expect(page).to have_content("#{@m2.name}: $13.50 Fulfilled Value")
+          expect(page).to have_content("#{@m4.name}: $13.50 Fulfilled Value")
         end
       end
 
@@ -308,16 +315,52 @@ RSpec.describe "merchant index workflow", type: :feature do
         visit merchants_path
 
         within("#top-ten-merchants-noncancelled-last-month") do
-          expect(page).to have_content("#{@m11.name}: 5 Items")
-          expect(page).to have_content("#{@m8.name}: 4 Items")
-          expect(page).to have_content("#{@m9.name}: 2 Items")
-          expect(page).to have_content("#{@m7.name}: 2 Items")
-          expect(page).to have_content("#{@m6.name}: 1 Item")
-          expect(page).to have_content("#{@m10.name}: 1 Item")
-          expect(page).to have_content("#{@m12.name}: 1 Item")
-          expect(page).to have_content("#{@m13.name}: 1 Item")
-          expect(page).to have_content("#{@m14.name}: 1 Item")
-          expect(page).to have_content("#{@m15.name}: 1 Item")
+          expect(page).to have_content("#{@m11.name}: $172.50 Fulfilled Value")
+          expect(page).to have_content("#{@m8.name}: $148.50 Fulfilled Value")
+          expect(page).to have_content("#{@m7.name}: $67.50 Fulfilled Value")
+          expect(page).to have_content("#{@m9.name}: $67.50 Fulfilled Value")
+          expect(page).to have_content("#{@m16.name}: $52.50 Fulfilled Value")
+          expect(page).to have_content("#{@m15.name}: $51.00 Fulfilled Value")
+          expect(page).to have_content("#{@m14.name}: $49.50 Fulfilled Value")
+          expect(page).to have_content("#{@m13.name}: $48.00 Fulfilled Value")
+          expect(page).to have_content("#{@m12.name}: $46.50 Fulfilled Value")
+          expect(page).to have_content("#{@m10.name}: $43.50 Fulfilled Value")
+          #limited to ten
+          expect(page).to_not have_content("#{@m6.name}: $40.50 Fulfilled Value")
+        end
+      end
+
+      it "top 5 merchants by fulfilled items fastest to my state" do
+        login_as(@u2)
+
+        visit merchants_path
+
+        within("#top-five-merchants-fulfilled-fastest-state") do
+          expect(page).to have_content("Top Merchants Who Fulfilled Orders Fastest To My State(IA)")
+          expect(page).to have_content("#{@m2.name}: 108 days 00 hours 00 minutes")
+          expect(page).to have_content("#{@m1.name}: 109 days 00 hours 00 minutes")
+          expect(page).to have_content("#{@m16.name}: 171 days 00 hours 00 minutes")
+          expect(page).to have_content("#{@m15.name}: 172 days 00 hours 00 minutes")
+          expect(page).to have_content("#{@m12.name}: 189 days 00 hours 00 minutes")
+          #limited to five
+          expect(page).to_not have_content("#{@m11.name}: 190 days 00 hours 00 minutes")
+        end
+      end
+
+      it "top 5 merchants by fulfilled items fastest to my city" do
+        login_as(@u4)
+
+        visit merchants_path
+
+        within("#top-five-merchants-fulfilled-fastest-city") do
+          expect(page).to have_content("Top Merchants Who Fulfilled Orders Fastest To My City(Des Moines, IA)")
+          expect(page).to have_content("#{@m16.name}: 171 days 00 hours 00 minutes")
+          expect(page).to have_content("#{@m15.name}: 172 days 00 hours 00 minutes")
+          expect(page).to have_content("#{@m3.name}: 208 days 00 hours 00 minutes")
+          expect(page).to have_content("#{@m4.name}: 209 days 00 hours 00 minutes")
+          expect(page).to have_content("#{@m5.name}: 210 days 00 hours 00 minutes")
+          #limited to five
+          expect(page).to_not have_content("#{@m6.name}: 211 days 00 hours 00 minutes")
         end
       end
 

--- a/spec/models/order_item_spec.rb
+++ b/spec/models/order_item_spec.rb
@@ -58,5 +58,39 @@ RSpec.describe OrderItem, type: :model do
       expect(oi2.fulfilled).to eq(true)
       expect(item.inventory).to eq(0)
     end
+
+    # it ".sold_this_month()" do
+    #   #travel_to Time.zone.local(2004, 11, 24, 01, 04, 44)
+    #   #now = Time.new(2019, 02, 23)
+    #   item = create(:item)
+    #   oi1 = create(:order_item, quantity: 1, item: item, updated_at: Time.new(2019, 02, 01))
+    #   oi2 = create(:order_item, quantity: 1, item: item, updated_at: Time.new(2019, 02, 12))
+    #   oi3 = create(:order_item, quantity: 1, item: item, updated_at: Time.new(2019, 01, 12))
+    #   oi4 = create(:order_item, quantity: 1, item: item, updated_at: Time.new(2018, 02, 01))
+    #
+    #   expect(oi1.sold_this_month(current)).to eq(true)
+    #   expect(oi2.sold_this_month(current)).to eq(true)
+    #   expect(oi3.sold_this_month(current)).to eq(false)
+    #   expect(oi4.sold_this_month(current)).to eq(false)
+    #
+    #   #travel_back
+    # end
+    #
+    # it ".sold_this_month()" do
+    #   #travel_to Time.zone.local(2004, 11, 24, 01, 04, 44)
+    #   #now = Time.new(2019, 02, 23)
+    #   item = create(:item)
+    #   oi1 = create(:order_item, quantity: 1, item: item, updated_at: Time.new(2019, 01, 01))
+    #   oi2 = create(:order_item, quantity: 1, item: item, updated_at: Time.new(2019, 01, 12))
+    #   oi3 = create(:order_item, quantity: 1, item: item, updated_at: Time.new(2019, 02, 12))
+    #   oi4 = create(:order_item, quantity: 1, item: item, updated_at: Time.new(2018, 01, 01))
+    #
+    #   expect(oi1.sold_this_month(last)).to eq(true)
+    #   expect(oi2.sold_this_month(last)).to eq(true)
+    #   expect(oi3.sold_this_month(last)).to eq(false)
+    #   expect(oi4.sold_this_month(last)).to eq(false)
+    #
+    #   #travel_back
+    # end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -183,6 +183,10 @@ RSpec.describe User, type: :model do
         expect(User.merchants_sorted_by_fulfilled_orders).to eq([@m11, @m3, @m2, @m4, @m1, @m5])
       end
 
+      it ".top_3_merchants_by_fulfilled_orders(current)" do
+        expect(User.top_merchants_by_fulfilled_orders(3)).to eq([@m11, @m3, @m2])
+      end
+
       #Month = next month
       it ".merchants_sorted_by_month_items(last)" do
         expect(User.merchants_sorted_by_month_items(Time.now.month - 1)).to eq([@m8, @m7, @m9, @m6, @m10])
@@ -190,6 +194,14 @@ RSpec.describe User, type: :model do
 
       it ".top_3_merchants_by_month_items(last)" do
         expect(User.top_merchants_by_month_items(3, Time.now.month - 1)).to eq([@m8, @m7, @m9])
+      end
+
+      it ".merchants_sorted_by_fulfilled_orders(last)" do
+        expect(User.merchants_sorted_by_fulfilled_orders(Time.now.month - 1)).to eq([@m11, @m8, @m7, @m9, @m6, @m10])
+      end
+
+      it ".top_3_merchants_by_fulfilled_orders(last)" do
+        expect(User.top_merchants_by_fulfilled_orders(3, Time.now.month - 1)).to eq([@m11, @m8, @m7])
       end
 
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe User, type: :model do
     describe "advanced-statistics" do
       before :each do
         u1 = create(:user)
-        @m1, @m2, @m3, @m4, @m5, @m6, @m7, @m8, @m9, @m10 = create_list(:merchant, 10)
+        @m1, @m2, @m3, @m4, @m5, @m6, @m7, @m8, @m9, @m10, @m11 = create_list(:merchant, 11)
         i1 = create(:item, merchant_id: @m1.id)
         i2 = create(:item, merchant_id: @m2.id)
         i3 = create(:item, merchant_id: @m3.id)
@@ -127,10 +127,10 @@ RSpec.describe User, type: :model do
         i8 = create(:item, merchant_id: @m8.id)
         i9 = create(:item, merchant_id: @m9.id)
         i10 = create(:item, merchant_id: @m10.id)
+        i11 = create(:item, merchant_id: @m11.id)
         o1, o2, o3, o4, o5, o6 , o7, o8 = create_list(:completed_order, 8, user: u1)
         o9 = create(:order, user: u1)
         o10 = create(:cancelled_order, user: u1)
-        o11 = create(:order, user: u1)
 
         #Order_items updated_at (fulfilled) current time (this month)
         oi1 = create(:fulfilled_order_item, item: i4, order: o1, quantity: 1, created_at: 200.days.ago)
@@ -151,8 +151,8 @@ RSpec.describe User, type: :model do
         oi12 = create(:order_item, item: i1, order: o8, created_at: 200.days.ago, quantity: 5)
         oi13 = create(:order_item, item: i1, order: o8, created_at: 200.days.ago, updated_at: 1.month.ago, quantity: 5)
         #Order pending
-        oi14 = create(:fulfilled_order_item, item: i1, order: o9, created_at: 200.days.ago, quantity: 5)
-        oi15 = create(:fulfilled_order_item, item: i1, order: o9, created_at: 200.days.ago, updated_at: 1.month.ago, quantity: 5)
+        oi14 = create(:fulfilled_order_item, item: i11, order: o9, created_at: 200.days.ago, quantity: 5)
+        oi15 = create(:fulfilled_order_item, item: i11, order: o9, created_at: 200.days.ago, updated_at: 1.month.ago, quantity: 5)
         #Order cancelled
         oi16 = create(:fulfilled_order_item, item: i1, order: o10, created_at: 200.days.ago, quantity: 5)
         oi17 = create(:fulfilled_order_item, item: i1, order: o10, created_at: 200.days.ago, updated_at: 1.month.ago, quantity: 5)
@@ -177,6 +177,10 @@ RSpec.describe User, type: :model do
 
       it ".top_3_merchants_by_month_items(current)" do
         expect(User.top_merchants_by_month_items(3)).to eq([@m3, @m2, @m4])
+      end
+
+      it ".merchants_sorted_by_fulfilled_orders(current)" do
+        expect(User.merchants_sorted_by_fulfilled_orders).to eq([@m11, @m3, @m2, @m4, @m1, @m5])
       end
 
       #Month = next month

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -145,17 +145,17 @@ RSpec.describe User, type: :model do
         oi10 = create(:fulfilled_order_item, item: i5, order: o6, quantity: 1, created_at: 200.days.ago)
 
         #Item not fulfilled this or last month
-        oi11 = create(:fulfilled_order_item, item: i1, order: o7, created_at: 200.days.ago, updated_at: 70.days.ago, quantity: 5)
+        oi11 = create(:fulfilled_order_item, item: i1, order: o7, created_at: 200.days.ago, updated_at: 2.months.ago, quantity: 5)
         oi28 = create(:fulfilled_order_item, item: i1, order: o7, created_at: 400.days.ago, updated_at: 1.year.ago, quantity: 5)
         #Item unfulfilled
-        oi12 = create(:order_item, item: i1, order: o8, created_at: 200.days.ago, updated_at: 3.days.ago, quantity: 5)
-        oi13 = create(:order_item, item: i1, order: o8, created_at: 200.days.ago, updated_at: 30.days.ago, quantity: 5)
+        oi12 = create(:order_item, item: i1, order: o8, created_at: 200.days.ago, quantity: 5)
+        oi13 = create(:order_item, item: i1, order: o8, created_at: 200.days.ago, updated_at: 1.month.ago, quantity: 5)
         #Order pending
-        oi14 = create(:fulfilled_order_item, item: i1, order: o9, created_at: 200.days.ago, updated_at: 3.days.ago, quantity: 5)
-        oi15 = create(:fulfilled_order_item, item: i1, order: o9, created_at: 200.days.ago, updated_at: 30.days.ago, quantity: 5)
+        oi14 = create(:fulfilled_order_item, item: i1, order: o9, created_at: 200.days.ago, quantity: 5)
+        oi15 = create(:fulfilled_order_item, item: i1, order: o9, created_at: 200.days.ago, updated_at: 1.month.ago, quantity: 5)
         #Order cancelled
-        oi16 = create(:fulfilled_order_item, item: i1, order: o10, created_at: 200.days.ago, updated_at: 3.days.ago, quantity: 5)
-        oi17 = create(:fulfilled_order_item, item: i1, order: o10, created_at: 200.days.ago, updated_at: 30.days.ago, quantity: 5)
+        oi16 = create(:fulfilled_order_item, item: i1, order: o10, created_at: 200.days.ago, quantity: 5)
+        oi17 = create(:fulfilled_order_item, item: i1, order: o10, created_at: 200.days.ago, updated_at: 1.month.ago, quantity: 5)
 
         #Order_items updated_at (fulfilled) 1 month ago (last month)
         oi18 = create(:fulfilled_order_item, item: i9, order: o1, quantity: 1, created_at: 200.days.ago, updated_at: 1.month.ago)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -57,6 +57,19 @@ RSpec.describe User, type: :model do
         oi5 = create(:order_item, item: i5, order: o5, created_at: 5.days.ago)
         oi6 = create(:fulfilled_order_item, item: i6, order: o6, created_at: 3.days.ago)
         oi7 = create(:fulfilled_order_item, item: i7, order: o7, created_at: 2.days.ago)
+
+
+        #
+        # oi16 = create(:fulfilled_order_item, item: i5, order: o1, created_at: 200.days.ago, updated_at: 30.days.ago)
+        # oi17 = create(:fulfilled_order_item, item: i6, order: o1, created_at: 200.days.ago, updated_at: 30.days.ago)
+        # oi18 = create(:fulfilled_order_item, item: i7, order: o1, created_at: 200.days.ago, updated_at: 30.days.ago)
+        # oi19 = create(:fulfilled_order_item, item: i5, order: o2, created_at: 200.days.ago, updated_at: 30.days.ago)
+        # oi20 = create(:fulfilled_order_item, item: i6, order: o2, created_at: 200.days.ago, updated_at: 30.days.ago)
+        # oi21 = create(:fulfilled_order_item, item: i5, order: o3, created_at: 200.days.ago, updated_at: 30.days.ago)
+        # oi22 = create(:fulfilled_order_item, item: i7, order: o4, created_at: 200.days.ago, updated_at: 30.days.ago)
+        # oi23 = create(:fulfilled_order_item, item: i4, order: o5, created_at: 200.days.ago, updated_at: 30.days.ago)
+
+        #oi24 = create(:order_item, item: i7, order: o3, created_at: 200.days.ago, updated_at: )
       end
       it ".merchants_sorted_by_revenue" do
         expect(User.merchants_sorted_by_revenue).to eq([@m7, @m6, @m3, @m2, @m1])
@@ -98,6 +111,82 @@ RSpec.describe User, type: :model do
         expect(User.top_user_cities_by_order_count(3)[2].city).to eq("Fairfield")
         expect(User.top_user_cities_by_order_count(3)[2].order_count).to eq(1)
       end
+    end
+
+    describe "advanced-statistics" do
+      before :each do
+        u1 = create(:user)
+        @m1, @m2, @m3, @m4, @m5, @m6, @m7, @m8, @m9, @m10 = create_list(:merchant, 10)
+        i1 = create(:item, merchant_id: @m1.id)
+        i2 = create(:item, merchant_id: @m2.id)
+        i3 = create(:item, merchant_id: @m3.id)
+        i4 = create(:item, merchant_id: @m4.id)
+        i5 = create(:item, merchant_id: @m5.id)
+        i6 = create(:item, merchant_id: @m6.id)
+        i7 = create(:item, merchant_id: @m7.id)
+        i8 = create(:item, merchant_id: @m8.id)
+        i9 = create(:item, merchant_id: @m9.id)
+        i10 = create(:item, merchant_id: @m10.id)
+        o1, o2, o3, o4, o5, o6 , o7, o8 = create_list(:completed_order, 8, user: u1)
+        o9 = create(:order, user: u1)
+        o10 = create(:cancelled_order, user: u1)
+
+
+        oi1 = create(:fulfilled_order_item, item: i4, order: o1, quantity: 1, created_at: 200.days.ago, updated_at: 3.days.ago)
+        oi2 = create(:fulfilled_order_item, item: i2, order: o1, quantity: 1, created_at: 200.days.ago, updated_at: 3.days.ago)
+        oi3 = create(:fulfilled_order_item, item: i3, order: o1, quantity: 1, created_at: 200.days.ago, updated_at: 3.days.ago)
+        oi4 = create(:fulfilled_order_item, item: i3, order: o2, quantity: 1, created_at: 200.days.ago, updated_at: 3.days.ago)
+        oi5 = create(:fulfilled_order_item, item: i2, order: o2, quantity: 1, created_at: 200.days.ago, updated_at: 3.days.ago)
+        oi6 = create(:fulfilled_order_item, item: i4, order: o3, quantity: 1, created_at: 200.days.ago, updated_at: 3.days.ago)
+        oi7 = create(:fulfilled_order_item, item: i3, order: o4, quantity: 1, created_at: 200.days.ago, updated_at: 3.days.ago)
+        oi8 = create(:fulfilled_order_item, item: i1, order: o5, quantity: 1, created_at: 200.days.ago, updated_at: 3.days.ago)
+        oi9 = create(:fulfilled_order_item, item: i3, order: o6, quantity: 1, created_at: 200.days.ago, updated_at: 10.days.ago)
+        oi10 = create(:fulfilled_order_item, item: i5, order: o6, quantity: 1, created_at: 200.days.ago, updated_at: 10.days.ago)
+
+        #Sad path testing
+        #Item not fulfilled this month
+        oi11 = create(:fulfilled_order_item, item: i1, order: o7, created_at: 200.days.ago, updated_at: 60.days.ago, quantity: 5)
+        #Item unfulfilled
+        oi12 = create(:order_item, item: i1, order: o8, created_at: 200.days.ago, updated_at: 3.days.ago, quantity: 5)
+        oi13 = create(:order_item, item: i1, order: o8, created_at: 200.days.ago, updated_at: 30.days.ago, quantity: 5)
+        #Order pending
+        oi14 = create(:fulfilled_order_item, item: i1, order: o9, created_at: 200.days.ago, updated_at: 3.days.ago, quantity: 5)
+        oi15 = create(:fulfilled_order_item, item: i1, order: o9, created_at: 200.days.ago, updated_at: 30.days.ago, quantity: 5)
+        #Order cancelled
+        oi16 = create(:fulfilled_order_item, item: i1, order: o10, created_at: 200.days.ago, updated_at: 3.days.ago, quantity: 5)
+        oi17 = create(:fulfilled_order_item, item: i1, order: o10, created_at: 200.days.ago, updated_at: 30.days.ago, quantity: 5)
+
+        oi18 = create(:fulfilled_order_item, item: i9, order: o1, quantity: 1, created_at: 200.days.ago, updated_at: 33.days.ago)
+        oi19 = create(:fulfilled_order_item, item: i7, order: o1, quantity: 1, created_at: 200.days.ago, updated_at: 33.days.ago)
+        oi20 = create(:fulfilled_order_item, item: i8, order: o1, quantity: 1, created_at: 200.days.ago, updated_at: 33.days.ago)
+        oi21 = create(:fulfilled_order_item, item: i8, order: o2, quantity: 1, created_at: 200.days.ago, updated_at: 33.days.ago)
+        oi22 = create(:fulfilled_order_item, item: i7, order: o2, quantity: 1, created_at: 200.days.ago, updated_at: 33.days.ago)
+        oi23 = create(:fulfilled_order_item, item: i9, order: o3, quantity: 1, created_at: 200.days.ago, updated_at: 33.days.ago)
+        oi24 = create(:fulfilled_order_item, item: i8, order: o4, quantity: 1, created_at: 200.days.ago, updated_at: 33.days.ago)
+        oi25 = create(:fulfilled_order_item, item: i6, order: o5, quantity: 1, created_at: 200.days.ago, updated_at: 33.days.ago)
+        oi26 = create(:fulfilled_order_item, item: i8, order: o6, quantity: 1, created_at: 200.days.ago, updated_at: 30.days.ago)
+        oi27 = create(:fulfilled_order_item, item: i10, order: o6, quantity: 1, created_at: 200.days.ago, updated_at: 30.days.ago)
+      end
+
+      #Month = current month(default)
+      it ".merchants_sorted_by_month_items()" do
+        expect(User.merchants_sorted_by_month_items).to eq([@m3, @m2, @m4, @m1, @m5])
+      end
+
+      it ".top_merchants_by_month_items()" do
+        expect(User.top_merchants_by_month_items(3)).to eq([@m3, @m2, @m4])
+      end
+
+      #Month = next month
+      it ".merchants_sorted_by_month_items()" do
+        expect(User.merchants_sorted_by_month_items(30.days.ago.month)).to eq([@m8, @m7, @m9, @m6, @m10])
+      end
+
+      it ".top_merchants_by_month_items()" do
+        expect(User.top_merchants_by_month_items(3)).to eq([@m3, @m2, @m4])
+      end
+
+
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -131,17 +131,17 @@ RSpec.describe User, type: :model do
         o9 = create(:order, user: u1)
         o10 = create(:cancelled_order, user: u1)
 
-
-        oi1 = create(:fulfilled_order_item, item: i4, order: o1, quantity: 1, created_at: 200.days.ago, updated_at: 3.days.ago)
-        oi2 = create(:fulfilled_order_item, item: i2, order: o1, quantity: 1, created_at: 200.days.ago, updated_at: 3.days.ago)
-        oi3 = create(:fulfilled_order_item, item: i3, order: o1, quantity: 1, created_at: 200.days.ago, updated_at: 3.days.ago)
-        oi4 = create(:fulfilled_order_item, item: i3, order: o2, quantity: 1, created_at: 200.days.ago, updated_at: 3.days.ago)
-        oi5 = create(:fulfilled_order_item, item: i2, order: o2, quantity: 1, created_at: 200.days.ago, updated_at: 3.days.ago)
-        oi6 = create(:fulfilled_order_item, item: i4, order: o3, quantity: 1, created_at: 200.days.ago, updated_at: 3.days.ago)
-        oi7 = create(:fulfilled_order_item, item: i3, order: o4, quantity: 1, created_at: 200.days.ago, updated_at: 3.days.ago)
-        oi8 = create(:fulfilled_order_item, item: i1, order: o5, quantity: 1, created_at: 200.days.ago, updated_at: 3.days.ago)
-        oi9 = create(:fulfilled_order_item, item: i3, order: o6, quantity: 1, created_at: 200.days.ago, updated_at: 10.days.ago)
-        oi10 = create(:fulfilled_order_item, item: i5, order: o6, quantity: 1, created_at: 200.days.ago, updated_at: 10.days.ago)
+        #Order_items updated_at (fulfilled) current time (this month)
+        oi1 = create(:fulfilled_order_item, item: i4, order: o1, quantity: 1, created_at: 200.days.ago)
+        oi2 = create(:fulfilled_order_item, item: i2, order: o1, quantity: 1, created_at: 200.days.ago)
+        oi3 = create(:fulfilled_order_item, item: i3, order: o1, quantity: 1, created_at: 200.days.ago)
+        oi4 = create(:fulfilled_order_item, item: i3, order: o2, quantity: 1, created_at: 200.days.ago)
+        oi5 = create(:fulfilled_order_item, item: i2, order: o2, quantity: 1, created_at: 200.days.ago)
+        oi6 = create(:fulfilled_order_item, item: i4, order: o3, quantity: 1, created_at: 200.days.ago)
+        oi7 = create(:fulfilled_order_item, item: i3, order: o4, quantity: 1, created_at: 200.days.ago)
+        oi8 = create(:fulfilled_order_item, item: i1, order: o5, quantity: 1, created_at: 200.days.ago)
+        oi9 = create(:fulfilled_order_item, item: i3, order: o6, quantity: 1, created_at: 200.days.ago)
+        oi10 = create(:fulfilled_order_item, item: i5, order: o6, quantity: 1, created_at: 200.days.ago)
 
         #Sad path testing
         #Item not fulfilled this month
@@ -156,34 +156,35 @@ RSpec.describe User, type: :model do
         oi16 = create(:fulfilled_order_item, item: i1, order: o10, created_at: 200.days.ago, updated_at: 3.days.ago, quantity: 5)
         oi17 = create(:fulfilled_order_item, item: i1, order: o10, created_at: 200.days.ago, updated_at: 30.days.ago, quantity: 5)
 
-        oi18 = create(:fulfilled_order_item, item: i9, order: o1, quantity: 1, created_at: 200.days.ago, updated_at: 33.days.ago)
-        oi19 = create(:fulfilled_order_item, item: i7, order: o1, quantity: 1, created_at: 200.days.ago, updated_at: 33.days.ago)
-        oi20 = create(:fulfilled_order_item, item: i8, order: o1, quantity: 1, created_at: 200.days.ago, updated_at: 33.days.ago)
-        oi21 = create(:fulfilled_order_item, item: i8, order: o2, quantity: 1, created_at: 200.days.ago, updated_at: 33.days.ago)
-        oi22 = create(:fulfilled_order_item, item: i7, order: o2, quantity: 1, created_at: 200.days.ago, updated_at: 33.days.ago)
-        oi23 = create(:fulfilled_order_item, item: i9, order: o3, quantity: 1, created_at: 200.days.ago, updated_at: 33.days.ago)
-        oi24 = create(:fulfilled_order_item, item: i8, order: o4, quantity: 1, created_at: 200.days.ago, updated_at: 33.days.ago)
-        oi25 = create(:fulfilled_order_item, item: i6, order: o5, quantity: 1, created_at: 200.days.ago, updated_at: 33.days.ago)
-        oi26 = create(:fulfilled_order_item, item: i8, order: o6, quantity: 1, created_at: 200.days.ago, updated_at: 30.days.ago)
-        oi27 = create(:fulfilled_order_item, item: i10, order: o6, quantity: 1, created_at: 200.days.ago, updated_at: 30.days.ago)
+        #Order_items updated_at (fulfilled) 1 month ago (last month)
+        oi18 = create(:fulfilled_order_item, item: i9, order: o1, quantity: 1, created_at: 200.days.ago, updated_at: 1.month.ago)
+        oi19 = create(:fulfilled_order_item, item: i7, order: o1, quantity: 1, created_at: 200.days.ago, updated_at: 1.month.ago)
+        oi20 = create(:fulfilled_order_item, item: i8, order: o1, quantity: 1, created_at: 200.days.ago, updated_at: 1.month.ago)
+        oi21 = create(:fulfilled_order_item, item: i8, order: o2, quantity: 1, created_at: 200.days.ago, updated_at: 1.month.ago)
+        oi22 = create(:fulfilled_order_item, item: i7, order: o2, quantity: 1, created_at: 200.days.ago, updated_at: 1.month.ago)
+        oi23 = create(:fulfilled_order_item, item: i9, order: o3, quantity: 1, created_at: 200.days.ago, updated_at: 1.month.ago)
+        oi24 = create(:fulfilled_order_item, item: i8, order: o4, quantity: 1, created_at: 200.days.ago, updated_at: 1.month.ago)
+        oi25 = create(:fulfilled_order_item, item: i6, order: o5, quantity: 1, created_at: 200.days.ago, updated_at: 1.month.ago)
+        oi26 = create(:fulfilled_order_item, item: i8, order: o6, quantity: 1, created_at: 200.days.ago, updated_at: 1.month.ago)
+        oi27 = create(:fulfilled_order_item, item: i10, order: o6, quantity: 1, created_at: 200.days.ago, updated_at: 1.month.ago)
       end
 
       #Month = current month(default)
-      it ".merchants_sorted_by_month_items()" do
+      it ".merchants_sorted_by_month_items(current)" do
         expect(User.merchants_sorted_by_month_items).to eq([@m3, @m2, @m4, @m1, @m5])
       end
 
-      it ".top_merchants_by_month_items()" do
+      it ".top_3_merchants_by_month_items(current)" do
         expect(User.top_merchants_by_month_items(3)).to eq([@m3, @m2, @m4])
       end
 
       #Month = next month
-      it ".merchants_sorted_by_month_items()" do
-        expect(User.merchants_sorted_by_month_items(30.days.ago.month)).to eq([@m8, @m7, @m9, @m6, @m10])
+      it ".merchants_sorted_by_month_items(last)" do
+        expect(User.merchants_sorted_by_month_items(Time.now.month - 1)).to eq([@m8, @m7, @m9, @m6, @m10])
       end
 
-      it ".top_merchants_by_month_items()" do
-        expect(User.top_merchants_by_month_items(3)).to eq([@m3, @m2, @m4])
+      it ".top_3_merchants_by_month_items(last)" do
+        expect(User.top_merchants_by_month_items(3, Time.now.month - 1)).to eq([@m8, @m7, @m9])
       end
 
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -57,19 +57,6 @@ RSpec.describe User, type: :model do
         oi5 = create(:order_item, item: i5, order: o5, created_at: 5.days.ago)
         oi6 = create(:fulfilled_order_item, item: i6, order: o6, created_at: 3.days.ago)
         oi7 = create(:fulfilled_order_item, item: i7, order: o7, created_at: 2.days.ago)
-
-
-        #
-        # oi16 = create(:fulfilled_order_item, item: i5, order: o1, created_at: 200.days.ago, updated_at: 30.days.ago)
-        # oi17 = create(:fulfilled_order_item, item: i6, order: o1, created_at: 200.days.ago, updated_at: 30.days.ago)
-        # oi18 = create(:fulfilled_order_item, item: i7, order: o1, created_at: 200.days.ago, updated_at: 30.days.ago)
-        # oi19 = create(:fulfilled_order_item, item: i5, order: o2, created_at: 200.days.ago, updated_at: 30.days.ago)
-        # oi20 = create(:fulfilled_order_item, item: i6, order: o2, created_at: 200.days.ago, updated_at: 30.days.ago)
-        # oi21 = create(:fulfilled_order_item, item: i5, order: o3, created_at: 200.days.ago, updated_at: 30.days.ago)
-        # oi22 = create(:fulfilled_order_item, item: i7, order: o4, created_at: 200.days.ago, updated_at: 30.days.ago)
-        # oi23 = create(:fulfilled_order_item, item: i4, order: o5, created_at: 200.days.ago, updated_at: 30.days.ago)
-
-        #oi24 = create(:order_item, item: i7, order: o3, created_at: 200.days.ago, updated_at: )
       end
       it ".merchants_sorted_by_revenue" do
         expect(User.merchants_sorted_by_revenue).to eq([@m7, @m6, @m3, @m2, @m1])
@@ -276,7 +263,6 @@ RSpec.describe User, type: :model do
 
         expect(User.top_merchants_by_fulfilled_orders_fastest_city(user_2, 3)).to eq([@m3, @m2, @m1])
       end
-
 
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -115,8 +115,11 @@ RSpec.describe User, type: :model do
 
     describe "advanced-statistics" do
       before :each do
-        u1 = create(:user)
-        @m1, @m2, @m3, @m4, @m5, @m6, @m7, @m8, @m9, @m10, @m11 = create_list(:merchant, 11)
+        @u1 = create(:user, state: "CO", city: "Fairfield")
+        @u2 = create(:user, state: "IA", city: "Fairfield")
+        @u3 = create(:user, state: "OK", city: "OKC")
+        @u4 = create(:user, state: "IA", city: "Des Moines")
+        @m1, @m2, @m3, @m4, @m5, @m6, @m7, @m8, @m9, @m10, @m11, @m12, @m13, @m14, @m15, @m16 = create_list(:merchant, 16)
         i1 = create(:item, merchant_id: @m1.id)
         i2 = create(:item, merchant_id: @m2.id)
         i3 = create(:item, merchant_id: @m3.id)
@@ -128,9 +131,19 @@ RSpec.describe User, type: :model do
         i9 = create(:item, merchant_id: @m9.id)
         i10 = create(:item, merchant_id: @m10.id)
         i11 = create(:item, merchant_id: @m11.id)
-        o1, o2, o3, o4, o5, o6 , o7, o8 = create_list(:completed_order, 8, user: u1)
-        o9 = create(:order, user: u1)
-        o10 = create(:cancelled_order, user: u1)
+        i12 = create(:item, merchant_id: @m12.id)
+        i13 = create(:item, merchant_id: @m13.id)
+        i14 = create(:item, merchant_id: @m14.id)
+        i15 = create(:item, merchant_id: @m15.id)
+        i16 = create(:item, merchant_id: @m16.id)
+        o1, o2, o3, o4, o5, o6 , o7, o8 = create_list(:completed_order, 8, user: @u1)
+        o9 = create(:order, user: @u1)
+        o10 = create(:cancelled_order, user: @u1)
+        o11 = create(:completed_order, user: @u2)
+        o12 = create(:completed_order, user: @u3)
+        o13 = create(:order, user: @u4)
+        o14 = create(:cancelled_order, user: @u4)
+
 
         #Order_items updated_at (fulfilled) current time (this month)
         oi1 = create(:fulfilled_order_item, item: i4, order: o1, quantity: 1, created_at: 200.days.ago)
@@ -146,7 +159,7 @@ RSpec.describe User, type: :model do
 
         #Item not fulfilled this or last month
         oi11 = create(:fulfilled_order_item, item: i1, order: o7, created_at: 200.days.ago, updated_at: 2.months.ago, quantity: 5)
-        oi28 = create(:fulfilled_order_item, item: i1, order: o7, created_at: 400.days.ago, updated_at: 1.year.ago, quantity: 5)
+        oi40 = create(:fulfilled_order_item, item: i1, order: o7, created_at: 400.days.ago, updated_at: 1.year.ago, quantity: 5)
         #Item unfulfilled
         oi12 = create(:order_item, item: i1, order: o8, created_at: 200.days.ago, quantity: 5)
         oi13 = create(:order_item, item: i1, order: o8, created_at: 200.days.ago, updated_at: 1.month.ago, quantity: 5)
@@ -168,6 +181,22 @@ RSpec.describe User, type: :model do
         oi25 = create(:fulfilled_order_item, item: i6, order: o5, quantity: 1, created_at: 200.days.ago, updated_at: 1.month.ago)
         oi26 = create(:fulfilled_order_item, item: i8, order: o6, quantity: 1, created_at: 200.days.ago, updated_at: 1.month.ago)
         oi27 = create(:fulfilled_order_item, item: i10, order: o6, quantity: 1, created_at: 200.days.ago, updated_at: 1.month.ago)
+
+        #Order_items updated not in last 2 months and by users in different states/cities
+        oi28 = create(:fulfilled_order_item, item: i11, order: o11, quantity: 1, created_at: 260.days.ago, updated_at: 100.days.ago)
+        oi29 = create(:fulfilled_order_item, item: i12, order: o11, quantity: 1, created_at: 250.days.ago, updated_at: 100.days.ago)
+        oi30 = create(:fulfilled_order_item, item: i13, order: o12, quantity: 1, created_at: 240.days.ago, updated_at: 100.days.ago)
+        oi31 = create(:fulfilled_order_item, item: i14, order: o12, quantity: 1, created_at: 230.days.ago, updated_at: 100.days.ago)
+        oi32 = create(:fulfilled_order_item, item: i15, order: o13, quantity: 1, created_at: 220.days.ago, updated_at: 100.days.ago)
+        oi33 = create(:fulfilled_order_item, item: i16, order: o13, quantity: 1, created_at: 210.days.ago, updated_at: 100.days.ago)
+        oi34 = create(:fulfilled_order_item, item: i1, order: o13, quantity: 1, created_at: 200.days.ago, updated_at: 100.days.ago)
+        oi35 = create(:fulfilled_order_item, item: i2, order: o13, quantity: 1, created_at: 190.days.ago, updated_at: 100.days.ago)
+        oi36 = create(:fulfilled_order_item, item: i3, order: o13, quantity: 1, created_at: 180.days.ago, updated_at: 100.days.ago)
+        #Order_item by same merchant, another state
+        oi37 = create(:fulfilled_order_item, item: i16, order: o1, quantity: 1, created_at: 110.days.ago, updated_at: 100.days.ago)
+        #Order_item by same merchant, same state, cancelled order
+        oi38 = create(:fulfilled_order_item, item: i16, order: o14, quantity: 1, created_at: 110.days.ago, updated_at: 100.days.ago)
+        #oi39 = create(:fulfilled_order_item, item: i16, order: o3, quantity: 1, created_at: 110.days.ago, updated_at: 100.days.ago)
       end
 
       #Month = current month(default)
@@ -202,6 +231,23 @@ RSpec.describe User, type: :model do
 
       it ".top_3_merchants_by_fulfilled_orders(last)" do
         expect(User.top_merchants_by_fulfilled_orders(3, Time.now.month - 1)).to eq([@m11, @m8, @m7])
+      end
+
+      #Fastest by user state
+      it ".merchants_sorted_by_fulfilled_orders_fastest_state()" do
+        user_2 = @u2
+        user_3 = @u3
+        user_4 = @u4
+
+        expect(User.merchants_sorted_by_fulfilled_orders_fastest_state(user_2)).to eq([@m3, @m2, @m1, @m16, @m15, @m12, @m11])
+        expect(User.merchants_sorted_by_fulfilled_orders_fastest_state(user_3)).to eq([@m14, @m13])
+        expect(User.merchants_sorted_by_fulfilled_orders_fastest_state(user_4)).to eq([@m3, @m2, @m1, @m16, @m15, @m12, @m11])
+      end
+
+      it ".top_3_merchants_by_fulfilled_orders_fastest_state()" do
+        user_2 = @u2
+        
+        expect(User.top_merchants_by_fulfilled_orders_fastest_state(user_2, 3)).to eq([@m3, @m2, @m1])
       end
 
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -226,7 +226,7 @@ RSpec.describe User, type: :model do
       end
 
       it ".merchants_sorted_by_fulfilled_orders(last)" do
-        merchants= User.merchants_sorted_by_fulfilled_orders(Time.now.month - 1)
+        merchants= User.merchants_sorted_by_fulfilled_orders(1.month.ago.month)
 
         expect(merchants).to eq([@m8, @m11, @m9, @m10, @m6, @m7])
         expect(merchants[0].total_revenue).to eq(136.5)
@@ -238,7 +238,7 @@ RSpec.describe User, type: :model do
       end
 
       it ".top_3_merchants_by_fulfilled_orders(last)" do
-        merchants = User.top_merchants_by_fulfilled_orders(3, Time.now.month - 1)
+        merchants = User.top_merchants_by_fulfilled_orders(3, 1.month.ago.month)
 
         expect(merchants).to eq([@m8, @m11, @m9])
       end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -141,9 +141,9 @@ RSpec.describe User, type: :model do
         o10 = create(:cancelled_order, user: @u1)
         o11 = create(:completed_order, user: @u2)
         o12 = create(:completed_order, user: @u3)
-        o13 = create(:order, user: @u4)
-        o14 = create(:cancelled_order, user: @u4)
-
+        o13 = create(:order, user: @u2)
+        o14 = create(:cancelled_order, user: @u2)
+        o15 = create(:cancelled_order, user: @u4)
 
         #Order_items updated_at (fulfilled) current time (this month)
         oi1 = create(:fulfilled_order_item, item: i4, order: o1, quantity: 1, created_at: 200.days.ago)
@@ -189,14 +189,14 @@ RSpec.describe User, type: :model do
         oi31 = create(:fulfilled_order_item, item: i14, order: o12, quantity: 1, created_at: 230.days.ago, updated_at: 100.days.ago)
         oi32 = create(:fulfilled_order_item, item: i15, order: o13, quantity: 1, created_at: 220.days.ago, updated_at: 100.days.ago)
         oi33 = create(:fulfilled_order_item, item: i16, order: o13, quantity: 1, created_at: 210.days.ago, updated_at: 100.days.ago)
-        oi34 = create(:fulfilled_order_item, item: i1, order: o13, quantity: 1, created_at: 200.days.ago, updated_at: 100.days.ago)
-        oi35 = create(:fulfilled_order_item, item: i2, order: o13, quantity: 1, created_at: 190.days.ago, updated_at: 100.days.ago)
-        oi36 = create(:fulfilled_order_item, item: i3, order: o13, quantity: 1, created_at: 180.days.ago, updated_at: 100.days.ago)
+        oi34 = create(:fulfilled_order_item, item: i1, order: o11, quantity: 1, created_at: 200.days.ago, updated_at: 100.days.ago)
+        oi35 = create(:fulfilled_order_item, item: i2, order: o11, quantity: 1, created_at: 190.days.ago, updated_at: 100.days.ago)
+        oi36 = create(:fulfilled_order_item, item: i3, order: o11, quantity: 1, created_at: 180.days.ago, updated_at: 100.days.ago)
         #Order_item by same merchant, another state
         oi37 = create(:fulfilled_order_item, item: i16, order: o1, quantity: 1, created_at: 110.days.ago, updated_at: 100.days.ago)
         #Order_item by same merchant, same state, cancelled order
         oi38 = create(:fulfilled_order_item, item: i16, order: o14, quantity: 1, created_at: 110.days.ago, updated_at: 100.days.ago)
-        #oi39 = create(:fulfilled_order_item, item: i16, order: o3, quantity: 1, created_at: 110.days.ago, updated_at: 100.days.ago)
+        oi39 = create(:fulfilled_order_item, item: i16, order: o15, quantity: 1, created_at: 110.days.ago, updated_at: 100.days.ago)
       end
 
       #Month = current month(default)
@@ -246,7 +246,24 @@ RSpec.describe User, type: :model do
 
       it ".top_3_merchants_by_fulfilled_orders_fastest_state()" do
         user_2 = @u2
-        
+
+        expect(User.top_merchants_by_fulfilled_orders_fastest_state(user_2, 3)).to eq([@m3, @m2, @m1])
+      end
+
+      #Fastest by user city
+      it ".merchants_sorted_by_fulfilled_orders_fastest_city()" do
+        user_2 = @u2
+        user_3 = @u3
+        user_4 = @u4
+
+        expect(User.merchants_sorted_by_fulfilled_orders_fastest_state(user_2)).to eq([@m3, @m2, @m1, @m12, @m11])
+        expect(User.merchants_sorted_by_fulfilled_orders_fastest_state(user_3)).to eq([@m14, @m13])
+        expect(User.merchants_sorted_by_fulfilled_orders_fastest_state(user_4)).to eq([@m16, @m15])
+      end
+
+      it ".top_3_merchants_by_fulfilled_orders_fastest_state()" do
+        user_2 = @u2
+
         expect(User.top_merchants_by_fulfilled_orders_fastest_state(user_2, 3)).to eq([@m3, @m2, @m1])
       end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -130,6 +130,7 @@ RSpec.describe User, type: :model do
         o1, o2, o3, o4, o5, o6 , o7, o8 = create_list(:completed_order, 8, user: u1)
         o9 = create(:order, user: u1)
         o10 = create(:cancelled_order, user: u1)
+        o11 = create(:order, user: u1)
 
         #Order_items updated_at (fulfilled) current time (this month)
         oi1 = create(:fulfilled_order_item, item: i4, order: o1, quantity: 1, created_at: 200.days.ago)
@@ -143,9 +144,9 @@ RSpec.describe User, type: :model do
         oi9 = create(:fulfilled_order_item, item: i3, order: o6, quantity: 1, created_at: 200.days.ago)
         oi10 = create(:fulfilled_order_item, item: i5, order: o6, quantity: 1, created_at: 200.days.ago)
 
-        #Sad path testing
-        #Item not fulfilled this month
-        oi11 = create(:fulfilled_order_item, item: i1, order: o7, created_at: 200.days.ago, updated_at: 60.days.ago, quantity: 5)
+        #Item not fulfilled this or last month
+        oi11 = create(:fulfilled_order_item, item: i1, order: o7, created_at: 200.days.ago, updated_at: 70.days.ago, quantity: 5)
+        oi28 = create(:fulfilled_order_item, item: i1, order: o7, created_at: 400.days.ago, updated_at: 1.year.ago, quantity: 5)
         #Item unfulfilled
         oi12 = create(:order_item, item: i1, order: o8, created_at: 200.days.ago, updated_at: 3.days.ago, quantity: 5)
         oi13 = create(:order_item, item: i1, order: o8, created_at: 200.days.ago, updated_at: 30.days.ago, quantity: 5)


### PR DESCRIPTION
More Merchant Stats
General Goal
Build a Merchant leaderboard as part of the "/merchants" page containing additional statistics that all users can see.

Completion criteria
Add the following leaderboard items:
Top 10 Merchants who sold the most items this month
Top 10 Merchants who sold the most items last month
Top 10 Merchants who fulfilled non-cancelled orders this month
Top 10 Merchants who fulfilled non-cancelled orders last month
When logged in as a user, the following stats are also displayed on the "/merchants" page as well:
Also see top 5 merchants who have fulfilled items the fastest to my state
Also see top 5 merchants who have fulfilled items the fastest to my city
Implementation Guidelines
It may be tricky to build any one portion of these statistics in a single ActiveRecord call. You can use multiple calls in a method to build these statistics, but allow the database to do the calculations, not Ruby.
Mod 2 Learning Goals reflected:
Advanced ActiveRecord
Software Testing
HTML/CSS layout and styling